### PR TITLE
fix: :bug: use singular entity keys to match intent classifier format [AI]

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -382,7 +382,7 @@ class TestSceneApplyCommand:
             raw_text="romantic",
             normalized_value="romantic",
             confidence=0.9,
-            metadata={},
+            metadata={"device_type": "scene"},
             linked_to=[],
         )
 
@@ -390,7 +390,7 @@ class TestSceneApplyCommand:
             id=uuid.uuid4(),
             intent_type=IntentType.SCENE_APPLY,
             confidence=0.9,
-            entities={"scenes": [scene_entity]},
+            entities={"device": [scene_entity]},
             alternative_intents=[],
             raw_text="activate romantic scene",
             timestamp=datetime.now(),
@@ -488,7 +488,7 @@ class TestMultipleScenes:
             raw_text="romantic",
             normalized_value="romantic",
             confidence=0.9,
-            metadata={},
+            metadata={"device_type": "scene"},
             linked_to=[],
         )
 
@@ -496,7 +496,7 @@ class TestMultipleScenes:
             id=uuid.uuid4(),
             intent_type=IntentType.SCENE_APPLY,
             confidence=0.9,
-            entities={"scenes": [scene_entity]},
+            entities={"device": [scene_entity]},
             alternative_intents=[],
             raw_text="activate romantic scene",
             timestamp=datetime.now(),
@@ -580,7 +580,7 @@ class TestSceneNotFound:
             raw_text="nonexistent",
             normalized_value="nonexistent",
             confidence=0.9,
-            metadata={},
+            metadata={"device_type": "scene"},
             linked_to=[],
         )
 
@@ -588,7 +588,7 @@ class TestSceneNotFound:
             id=uuid.uuid4(),
             intent_type=IntentType.SCENE_APPLY,
             confidence=0.9,
-            entities={"scenes": [scene_entity]},
+            entities={"device": [scene_entity]},
             alternative_intents=[],
             raw_text="activate nonexistent scene",
             timestamp=datetime.now(),

--- a/tests/test_scene_skill.py
+++ b/tests/test_scene_skill.py
@@ -202,11 +202,12 @@ async def test_handle_scene_apply_success(scene_skill, monkeypatch):
     # Mock classified intent and client request
     mock_entity = Mock()
     mock_entity.normalized_value = "romantic"
+    mock_entity.metadata = {"device_type": "scene"}
 
     mock_classified_intent = Mock()
     mock_classified_intent.intent_type = IntentType.SCENE_APPLY
     mock_classified_intent.confidence = 0.9
-    mock_classified_intent.entities = {"scenes": [mock_entity], "rooms": []}
+    mock_classified_intent.entities = {"device": [mock_entity]}
 
     mock_client_request = Mock()
     mock_client_request.room = "living room"
@@ -244,11 +245,12 @@ async def test_handle_scene_apply_not_found(scene_skill, monkeypatch):
     # Mock classified intent with non-existent scene
     mock_entity = Mock()
     mock_entity.normalized_value = "nonexistent"
+    mock_entity.metadata = {"device_type": "scene"}
 
     mock_classified_intent = Mock()
     mock_classified_intent.intent_type = IntentType.SCENE_APPLY
     mock_classified_intent.confidence = 0.9
-    mock_classified_intent.entities = {"scenes": [mock_entity], "rooms": []}
+    mock_classified_intent.entities = {"device": [mock_entity]}
 
     mock_client_request = Mock()
     mock_client_request.room = "living room"

--- a/uv.lock
+++ b/uv.lock
@@ -308,7 +308,7 @@ wheels = [
 
 [[package]]
 name = "private-assistant-scene-skill"
-version = "2.0.1"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
Intent classifier sends entities with singular keys ('device', 'room') but skill was using plural ('scenes', 'rooms'). This caused all scenes to activate instead of just the requested one.